### PR TITLE
Fix argument handling in `Cursor_fetchdictarray`

### DIFF
--- a/src/npyodbcmodule.cpp
+++ b/src/npyodbcmodule.cpp
@@ -23,6 +23,7 @@ PyInit_npyodbc(void)
     // to the module can be done here.
     // PyObject *module = PyInit_pyodbc();
     PyInit_pyodbc();
+
     if (pModule == NULL) {
         PyErr_SetString(PyExc_ImportError, "Error initializing pyodbc.");
         return NULL;


### PR DESCRIPTION
This PR fixes a few issues with `Cursor_fetchdictarray`. Fixes #37.

1. Added documentation about the parameters.
2. Change `0` to `NULL` for pointer comparisons, except in the output
3. Simplified and clarified logic around checking whether nulls should be returned
4. Added a `NULL` sentinel to `Cursor_npfetch_kwnames`. It's pure luck that we didn't see this issue before, as without this sentinel `PyArg_ParseTupleAndKeywords` will read past the end of the array. If the next byte is a null byte everything works just fine, but if not you get a segfault, which is what led to this issue in the first place.

I also attempted to move `import_array` to module initialization, thinking that there is no need to call it every time `fetchdictarray` is called, but for some reason `PyArray_GetNDArrayCFeatureVersion()` segfaults (?!) if you do this. If you move this into module initialization as well, then `PyArray_DescrFromType(NPY_INT32)` segfaults (?????). This module seems pretty fragile, so I'm just going to leave this as is for now.