### PR TITLE
Update pyodbc classes to have npyodbc module name

### DIFF
--- a/subprojects/packagefiles/patches/cnxninfo.patch
+++ b/subprojects/packagefiles/patches/cnxninfo.patch
@@ -1,0 +1,11 @@
+--- a/src/cnxninfo.cpp
++++ b/src/cnxninfo.cpp
+@@ -167,7 +167,7 @@ PyObject* GetConnectionInfo(PyObject* pConnectionString, Connection* cnxn)
+ PyTypeObject CnxnInfoType =
+ {
+     PyVarObject_HEAD_INIT(0, 0)
+-    "pyodbc.CnxnInfo",                                      // tp_name
++    "npyodbc.CnxnInfo",                                      // tp_name
+     sizeof(CnxnInfo),                                       // tp_basicsize
+     0,                                                      // tp_itemsize
+     0,                                                      // destructor tp_dealloc

--- a/subprojects/packagefiles/patches/connection.patch
+++ b/subprojects/packagefiles/patches/connection.patch
@@ -1,0 +1,11 @@
+--- a/src/connection.cpp
++++ b/src/connection.cpp
+@@ -1400,7 +1400,7 @@ static PyGetSetDef Connection_getseters[] = {
+ PyTypeObject ConnectionType =
+ {
+     PyVarObject_HEAD_INIT(0, 0)
+-    "pyodbc.Connection",        // tp_name
++    "npyodbc.Connection",        // tp_name
+     sizeof(Connection),         // tp_basicsize
+     0,                          // tp_itemsize
+     Connection_dealloc,         // destructor tp_dealloc

--- a/subprojects/packagefiles/patches/cursor.patch
+++ b/subprojects/packagefiles/patches/cursor.patch
@@ -25,7 +25,7 @@
  {
      //  Validates that a PyObject is a Cursor (like Cursor_Check) and optionally some other requirements controlled by
      //  `flags`.  If valid and all requirements (from the flags) are met, the cursor is returned, cast to Cursor*.
-@@ -2396,6 +2389,7 @@ static PyMethodDef Cursor_methods[] =
+@@ -2394,6 +2387,7 @@ static PyMethodDef Cursor_methods[] =
      { "fetchone",         (PyCFunction)Cursor_fetchone,         METH_NOARGS,                fetchone_doc         },
      { "fetchall",         (PyCFunction)Cursor_fetchall,         METH_NOARGS,                fetchall_doc         },
      { "fetchmany",        (PyCFunction)Cursor_fetchmany,        METH_VARARGS,               fetchmany_doc        },
@@ -33,8 +33,15 @@
      { "nextset",          (PyCFunction)Cursor_nextset,          METH_NOARGS,                nextset_doc          },
      { "tables",           (PyCFunction)Cursor_tables,           METH_VARARGS|METH_KEYWORDS, tables_doc           },
      { "columns",          (PyCFunction)Cursor_columns,          METH_VARARGS|METH_KEYWORDS, columns_doc          },
-diff --git a/src/cursor.h b/src/cursor.h
-index 657eb48..d7a5050 100644
+@@ -2430,7 +2424,7 @@ static char cursor_doc[] =
+ PyTypeObject CursorType =
+ {
+     PyVarObject_HEAD_INIT(0, 0)
+-    "pyodbc.Cursor",                                        // tp_name
++    "npyodbc.Cursor",                                       // tp_name
+     sizeof(Cursor),                                         // tp_basicsize
+     0,                                                      // tp_itemsize
+     (destructor)Cursor_dealloc,                             // destructor tp_dealloc
 --- a/src/cursor.h
 +++ b/src/cursor.h
 @@ -13,6 +13,14 @@
@@ -60,4 +67,3 @@ index 657eb48..d7a5050 100644
 
  #endif
 --
-2.45.2

--- a/subprojects/packagefiles/patches/params.patch
+++ b/subprojects/packagefiles/patches/params.patch
@@ -1,0 +1,11 @@
+--- a/src/params.cpp
++++ b/src/params.cpp
+@@ -1864,7 +1864,7 @@ struct NullParam
+ PyTypeObject NullParamType =
+ {
+     PyVarObject_HEAD_INIT(NULL, 0)
+-    "pyodbc.NullParam",         // tp_name
++    "npyodbc.NullParam",         // tp_name
+     sizeof(NullParam),          // tp_basicsize
+     0,                          // tp_itemsize
+     0,                          // destructor tp_dealloc

--- a/subprojects/packagefiles/patches/pyodbcmodule.patch
+++ b/subprojects/packagefiles/patches/pyodbcmodule.patch
@@ -45,7 +45,7 @@
      "connection string.  (If you must use these in your connection string, pass them\n"
      "as a string, not as keywords.)\n"
      "\n"
-@@ -1148,7 +1148,7 @@ static bool CreateExceptions()
+@@ -1149,7 +1149,7 @@ static bool CreateExceptions()
 
  static struct PyModuleDef moduledef = {
      PyModuleDef_HEAD_INIT,
@@ -54,5 +54,3 @@
      module_doc,
      -1,                         // m_size
      pyodbc_methods,             // m_methods
---
-2.45.2

--- a/subprojects/packagefiles/patches/row.patch
+++ b/subprojects/packagefiles/patches/row.patch
@@ -1,0 +1,11 @@
+--- a/src/row.cpp
++++ b/src/row.cpp
+@@ -453,7 +453,7 @@ static char row_doc[] =
+ PyTypeObject RowType =
+ {
+     PyVarObject_HEAD_INIT(NULL, 0)
+-    "pyodbc.Row",                                           // tp_name
++    "npyodbc.Row",                                           // tp_name
+     sizeof(Row),                                            // tp_basicsize
+     0,                                                      // tp_itemsize
+     Row_dealloc,                                            // tp_dealloc


### PR DESCRIPTION
This PR updates the `pyodbc` classes to have `npyodbc` as their `__module__`, reflecting their true association. Closes #61.